### PR TITLE
Releasing v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v1.3.0](https://github.com/YashdalfTheGray/auto-ngtemplate-loader/tree/v1.3.0) (2018-02-21)
+
+### Added
+
+* The `pathResolver` function now works with versions as old as Webpack v1 using an `autoNgTemplateLoader` key in the Webpack configuration object
+
+
 ## [v1.2.0](https://github.com/YashdalfTheGray/auto-ngtemplate-loader/tree/v1.2.0) (2018-02-16)
 
 ### Added
 
-* A `pathResolver` loader option that helps with resolving root-relative paths and adapts to various project structures. 
+* A `pathResolver` loader option that helps with resolving root-relative paths and adapts to various project structures
+
 
 ## [v1.1.0](https://github.com/YashdalfTheGray/auto-ngtemplate-loader/tree/v1.1.0) (2017-06-11)
 
@@ -19,15 +27,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Paths not prefixed with `./` in the DDO no longer cause problems
 
+
 ## [v1.0.2](https://github.com/YashdalfTheGray/auto-ngtemplate-loader/tree/v1.0.2) (2017-06-09)
 
 ### Fixed
 * Properly handle the case where `templateUrl` is not set to a string
 
+
 ## [v1.0.1](https://github.com/YashdalfTheGray/auto-ngtemplate-loader/tree/v1.0.1) (2017-06-04)
 
 ### Fixed
 * Added `yarn.lock` to the ignored files in NPM
+
 
 ## [v1.0.0](https://github.com/YashdalfTheGray/auto-ngtemplate-loader/tree/v1.0.0) (2017-06-04)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This module supports configuration through either the `options` object method or
 
 ### Webpack v1 Compatible Options
 
-Since Webpack v1 only supports query strings for loaders and doesn't allow passing a function as an option, this loader has a `useResolverFromConfig` boolean option that can be passed in through the query string and the loader will look for the resolver in the Webpack configuration object under the key `autoNgTemplateLoader`. The only acceptable member of `autoNgTemplateLoader` is `pathResolver` which should be a function that returns a string for all cases. An example is below.
+Since Webpack v1 only supports query strings for loaders and doesn't allow passing a function as an option, this loader has a `useResolverFromConfig` boolean option that can be passed in through the query string. The loader will look for the resolver in the Webpack configuration object under the key `autoNgTemplateLoader`. The only acceptable member of `autoNgTemplateLoader` is `pathResolver` which should be a function that returns a string for all cases. An example is below.
 
 ```javascript
 module.exports = {
@@ -82,7 +82,7 @@ module.exports = {
 };
 ```
 
-**Note**: The loader will throw an error if `useResolverFromConfig` is used in Webpack v2 or newer. The recommended way to pass the function is through the options in that case. This is because the Loader API v2 has deprecated a property that is used for the v1 workaround and going forward, the loader will not use it. 
+**Note**: The loader will throw an error if `useResolverFromConfig` is used in Webpack v2 or newer. The recommended way to pass the function is through the options in that case. This is because the Loader API v2 has deprecated a property that is used for the v1 workaround. The loader will check the version and report an error. 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,32 @@ This module supports configuration through either the `options` object method or
 | `variableName` | `string`   | `autoNgTemplateLoaderTemplate` | The variable name that gets injected into the compiled code. This is included so that variable collisions can be prevented.  |
 | `pathResolver` | `(path: string) => string` | [`urlToRequest`](https://github.com/webpack/loader-utils#urltorequest) | This function can be used to customize the require path in cases where templates don't use relative paths. This function is called with the path of the template and must return a string which is a valid path.
 
+### Webpack v1 Compatible Options
+
+Since Webpack v1 only supports query strings for loaders and doesn't allow passing a function as an option, this loader has a `useResolverFromConfig` boolean option that can be passed in through the query string and the loader will look for the resolver in the Webpack configuration object under the key `autoNgTemplateLoader`. The only acceptable member of `autoNgTemplateLoader` is `pathResolver` which should be a function that returns a string for all cases. An example is below.
+
+```javascript
+module.exports = {
+    autoNgTemplateLoader: {
+        pathResolver: p => p.replace(/src/, '..').substring(1)
+    },
+    module: {
+        loaders: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                loader: 'babel-loader!auto-ngtemplate-loader?variableName=testVar&useResolverFromConfig=true'
+            }
+        ]
+    }
+};
+```
+
+**Note**: The loader will throw an error if `useResolverFromConfig` is used in Webpack v2 or newer. The recommended way to pass the function is through the options in that case. This is because the Loader API v2 has deprecated a property that is used for the v1 workaround and going forward, the loader will not use it. 
+
 ## Development
+
+Please follow the guidelines in the [contribution guide](.github/CONTRIBUTING.md) for development.
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-ngtemplate-loader",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-ngtemplate-loader",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Auto require AngularJS 1.x templates in Webpack style",
   "main": "index.js",
   "repository": "https://github.com/yashdalfthegray/auto-ngtemplate-loader",

--- a/src/auto-ngtemplate-loader.js
+++ b/src/auto-ngtemplate-loader.js
@@ -24,7 +24,7 @@ module.exports = function autoNgTemplateLoader(source, map) {
             return;
         }
 
-        resolverFromConfig = _.get(this.options.autoNgTemplateLoader.pathResolver);
+        resolverFromConfig = _.get(this, 'options.autoNgTemplateLoader.pathResolver');
 
         if (!resolverFromConfig) {
             this.callback(

--- a/src/auto-ngtemplate-loader.js
+++ b/src/auto-ngtemplate-loader.js
@@ -5,10 +5,14 @@ const { isValid } = require('var-validator');
 const { replaceTemplateUrl } = require('./util');
 
 module.exports = function autoNgTemplateLoader(source, map) {
-    const { variableName = 'autoNgTemplateLoaderTemplate', pathResolver } = loaderUtils.getOptions(this) || {};
+    const {
+        variableName = 'autoNgTemplateLoaderTemplate',
+        pathResolver,
+        useResolverFromConfig = false
+    } = loaderUtils.getOptions(this) || {};
 
-    if (pathResolver && typeof pathResolver(this.resourcePath) !== 'string') {
-        this.callback(new Error('The path resolver function does not return a string'), null, null);
+    if (useResolverFromConfig && this.version > 1) {
+        this.callback(new Error('Resolver required to be passed as an option with Webpack v2'), null, null);
         return;
     }
 
@@ -22,6 +26,11 @@ module.exports = function autoNgTemplateLoader(source, map) {
         return;
     }
 
-    const newSource = replaceTemplateUrl(variableName, source.split('\n'), pathResolver).join('\n');
-    this.callback(null, newSource, map);
+    try {
+        const newSource = replaceTemplateUrl(variableName, source.split('\n'), pathResolver).join('\n');
+        this.callback(null, newSource, map);
+    }
+    catch (e) {
+        this.callback(e, null, null);
+    }
 };

--- a/src/auto-ngtemplate-loader.js
+++ b/src/auto-ngtemplate-loader.js
@@ -1,19 +1,44 @@
 const loaderUtils = require('loader-utils');
 const { escapeRegExp } = require('lodash');
 const { isValid } = require('var-validator');
+const _ = require('lodash');
 
 const { replaceTemplateUrl } = require('./util');
 
 module.exports = function autoNgTemplateLoader(source, map) {
+    let resolverFunc;
+    let resolverFromConfig;
     const {
         variableName = 'autoNgTemplateLoaderTemplate',
         pathResolver,
         useResolverFromConfig = false
     } = loaderUtils.getOptions(this) || {};
 
-    if (useResolverFromConfig && this.version > 1) {
-        this.callback(new Error('Resolver required to be passed as an option with Webpack v2'), null, null);
-        return;
+    if (useResolverFromConfig) {
+        if (this.version > 1) {
+            this.callback(
+                new Error('Resolver required to be passed as an option with Webpack v2'),
+                null,
+                null
+            );
+            return;
+        }
+
+        resolverFromConfig = _.get(this.options.autoNgTemplateLoader.pathResolver);
+
+        if (!resolverFromConfig) {
+            this.callback(
+                new Error('function pathResolver not found in autoNgTemplateLoader in the config'),
+                null,
+                null
+            );
+            return;
+        }
+
+        resolverFunc = resolverFromConfig;
+    }
+    else {
+        resolverFunc = pathResolver;
     }
 
     if (!isValid(variableName)) {
@@ -27,7 +52,7 @@ module.exports = function autoNgTemplateLoader(source, map) {
     }
 
     try {
-        const newSource = replaceTemplateUrl(variableName, source.split('\n'), pathResolver).join('\n');
+        const newSource = replaceTemplateUrl(variableName, source.split('\n'), resolverFunc).join('\n');
         this.callback(null, newSource, map);
     }
     catch (e) {

--- a/src/auto-ngtemplate-loader.spec.js
+++ b/src/auto-ngtemplate-loader.spec.js
@@ -62,34 +62,19 @@ test('loader throws an error when variable is not valid', (t) => {
     loader.call(context, testDirective1);
 });
 
-test('loader throws an error when the resolver function does not return a string', (t) => {
+test('loader throws an error if webpack v2 and useResolverFromConfig is true', (t) => {
     t.plan(2);
 
     const context = {
         callback: function callback(err, source) {
-            t.deepEqual(err, new Error('The path resolver function does not return a string'));
+            t.deepEqual(err, new Error('Resolver required to be passed as an option with Webpack v2'));
             t.is(source, null);
         },
         query: {
             variableName: 'testVariable',
-            pathResolver: () => 1
-        }
-    };
-
-    loader.call(context, testDirective1);
-});
-
-test('loader accepts a function returning a string as the pathResolver', (t) => {
-    t.plan(1);
-
-    const context = {
-        callback: function callback(err) {
-            t.is(err, null);
+            useResolverFromConfig: true
         },
-        query: {
-            variableName: 'testVariable',
-            pathResolver: p => `'string'${p}`
-        }
+        version: 2
     };
 
     loader.call(context, testDirective1);

--- a/src/auto-ngtemplate-loader.spec.js
+++ b/src/auto-ngtemplate-loader.spec.js
@@ -1,4 +1,5 @@
 const test = require('ava');
+const { urlToRequest } = require('loader-utils');
 
 const loader = require('./auto-ngtemplate-loader');
 const { testDirective1, testDirective1Replaced } = require('./testdata');
@@ -75,6 +76,47 @@ test('loader throws an error if webpack v2 and useResolverFromConfig is true', (
             useResolverFromConfig: true
         },
         version: 2
+    };
+
+    loader.call(context, testDirective1);
+});
+
+test('loader throws an error if useResolverFromConfig is true and no resolver found', (t) => {
+    t.plan(2);
+
+    const context = {
+        callback: function callback(err, source) {
+            t.deepEqual(err, new Error('function pathResolver not found in autoNgTemplateLoader in the config'));
+            t.is(source, null);
+        },
+        query: {
+            variableName: 'testVariable',
+            useResolverFromConfig: true
+        },
+        version: 1
+    };
+
+    loader.call(context, testDirective1);
+});
+
+test('accepts a function from the config if webpack v1', (t) => {
+    t.plan(2);
+
+    const context = {
+        callback: function callback(err, source) {
+            t.is(err, null);
+            t.is(source, testDirective1Replaced('testVariable'));
+        },
+        query: {
+            variableName: 'testVariable',
+            useResolverFromConfig: true
+        },
+        version: 1,
+        options: {
+            autoNgTemplateLoader: {
+                pathResolver: urlToRequest
+            }
+        }
     };
 
     loader.call(context, testDirective1);

--- a/src/util.js
+++ b/src/util.js
@@ -16,6 +16,10 @@ function replaceTemplateUrl(variableName, lines, resolver) {
             return null;
         }
 
+        if (resolver && typeof resolver(templateUrl) !== 'string') {
+            throw new Error(`Expected path resolver to return string for ${templateUrl}`);
+        }
+
         const lineReplacement = lines[lineNumber].replace(regEx, `$1${variableName}${i + 1}$3`);
 
         return {

--- a/src/util.spec.js
+++ b/src/util.spec.js
@@ -67,3 +67,10 @@ test('replaceTemplateUrl handles a template in a subdirectory', (t) => {
         replaceTemplateUrl(variableName, differentPath2.split('\n')), differentPath2Replaced().split('\n')
     );
 });
+
+
+test('resolver not returning a string throws error', (t) => {
+    t.throws(() => replaceTemplateUrl(
+        variableName, testDirective1.split('\n'), () => 1
+    ));
+});


### PR DESCRIPTION
## [v1.3.0](https://github.com/YashdalfTheGray/auto-ngtemplate-loader/tree/v1.3.0) (2018-02-21)

### Added

* The `pathResolver` function now works with versions as old as Webpack v1 using an `autoNgTemplateLoader` key in the Webpack configuration object