### PR TITLE
fix template variable when templateUrl is null

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -31,7 +31,9 @@ function replaceTemplateUrl(variableName, lines, resolver) {
         `$1${variableName}${i + 1}$3`
       );
 
+      const lineVariable = `${variableName}${i + 1}`
       return {
+        lineVariable,
         templateUrl,
         lineNumber,
         lineReplacement
@@ -52,7 +54,7 @@ function replaceTemplateUrl(variableName, lines, resolver) {
   return [
     ...templateRequires.map(
       (x, i) =>
-        `const ${variableName}${i + 1} = require('${resolverFunc(
+        `const ${x.lineVariable} = require('${resolverFunc(
           x.templateUrl
         )}');`
     ),

--- a/src/util.js
+++ b/src/util.js
@@ -15,6 +15,7 @@ function replaceTemplateUrl(variableName, lines, resolver) {
   const templateRequires = lineNumbers
     .map((lineNumber, i) => {
       const [, , templateUrl] = regEx.exec(lines[lineNumber]) || [];
+      const lineVariable = `${variableName}${i + 1}`;
 
       if (!templateUrl) {
         return null;
@@ -28,10 +29,9 @@ function replaceTemplateUrl(variableName, lines, resolver) {
 
       const lineReplacement = lines[lineNumber].replace(
         regEx,
-        `$1${variableName}${i + 1}$3`
+        `$1${lineVariable}$3`
       );
 
-      const lineVariable = `${variableName}${i + 1}`
       return {
         lineVariable,
         templateUrl,
@@ -53,10 +53,8 @@ function replaceTemplateUrl(variableName, lines, resolver) {
 
   return [
     ...templateRequires.map(
-      (x, i) =>
-        `const ${x.lineVariable} = require('${resolverFunc(
-          x.templateUrl
-        )}');`
+      x =>
+        `const ${x.lineVariable} = require('${resolverFunc(x.templateUrl)}');`
     ),
     ``,
     ...updatedLines


### PR DESCRIPTION
#### Related issues (if any)
issue number/none

#### Type of request
🐛Bugfix

#### Proposed milestone
🥉Patch

#### Describe changes
I found out the variable name is set with iteration number of array lineNumbers on [util.js](https://github.com/YashdalfTheGray/auto-ngtemplate-loader/blob/master/src/util.js). so when 1st loop returned null in the middle of the loop, the second loop will be returned the wrong required template.

here the screenshot: http://prntscr.com/ms0vh9