### PR TITLE
Releasing auto-ngtemplate-loader v3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - npm run many-directives
   - npm run multiple-directives
   - npm run absolute-paths
+  - npm run separated-templates
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ os:
   - windows
 
 node_js:
-  - 'node'
-  - '14'
-  - '12'
-  - '10'
+  - "node"
+  - "14"
+  - "12"
+  - "10"
 
 install:
   - npm install
@@ -25,4 +25,4 @@ script:
 
 cache:
   directories:
-    - 'node_modules'
+    - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ node_js:
   - "10"
 
 install:
-  - npm install
+  - npm ci
 
 script:
   - npm test


### PR DESCRIPTION
#### Type of request
🎉Release

#### Proposed milestone
🥇Major

#### Breaking

- `auto-ngtemplate-loader` no longer supports Node.js v8.x

#### Fixed

- Updated outdated npm packages
- Added new node versions
